### PR TITLE
Latest Jetty version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ In the site.pp manifest:
 # Jetty
 
 $jetty_home = "/opt/" # this will create a /opt/jetty-$jetty_version folder and a /opt/jetty linking to it
-$jetty_version = "7.4.2.v20110526"
+$jetty_version = "9.0.4.v20130625"
 include jetty
 ```

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,7 +1,7 @@
 class jetty {
   include wget
   wget::fetch { "jetty_download":
-    source => "http://archive.eclipse.org/jetty/$jetty_version/dist/jetty-distribution-$jetty_version.tar.gz",
+    source => "http://eclipse.org/downloads/download.php?file=/jetty/$jetty_version/dist/jetty-distribution-$jetty_version.tar.gz&r=1",
     destination => "/usr/local/src/jetty-distribution-$jetty_version.tar.gz",
   } ->
   exec { "jetty_untar":


### PR DESCRIPTION
Switched from archive.eclipse.org to eclipse.org/download.php to support latest Jetty version. Need to fix puppet-wget quote handling, as said in https://github.com/maestrodev/puppet-wget/pull/10
