### PR TITLE
Add user/group management, defaults file and change chown method

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,7 +50,7 @@ class jetty (
   } ->
 
   file { "/etc/default/jetty":
-    source => template('jetty/default');
+    content => template('jetty/default');
   } ->
 
   file { "/etc/init.d/jetty":

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,40 +1,66 @@
-class jetty(
+class jetty (
   $version,
-  $home = "/opt",
-  $user = "jetty",
-  $group = "jetty") {
+  $home        = "/opt",
+  $manage_user = false,
+  $user        = "jetty",
+  $group       = "jetty",
+) {
 
   include wget
+
+  if $manage_user {
+    user { "$user":
+      ensure => present,
+      managehome => true,
+      system => true;
+    }
+
+    group { "$group":
+      ensure => present;
+    }
+  }
 
   wget::fetch { "jetty_download":
     source      => "http://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/${version}/jetty-distribution-${version}.tar.gz",
     destination => "/usr/local/src/jetty-distribution-${version}.tar.gz",
   } ->
+
   exec { "jetty_untar":
-    command => "tar xf /usr/local/src/jetty-distribution-${version}.tar.gz && chown -R ${user}:${group} ${home}/jetty-distribution-${version}",
+    command => "tar xf /usr/local/src/jetty-distribution-${version}.tar.gz",
     cwd     => $home,
     creates => "${home}/jetty-distribution-${version}",
     path    => ["/bin",],
-    notify  => Service["jetty"]
+    require => [User[$user], Group[$group]]; 
+  } ->
+
+  file { "${home}/jetty-distribution-${version}":
+    ensure  => directory,
+    recurse => true,
+    backup  => false,
+    owner   => $user,
+    group   => $group;
   } ->
   
   file { "${home}/jetty":
-    ensure  => "${home}/jetty-distribution-${version}",
+    ensure  => "${home}/jetty-distribution-${version}";
   } ->
 
   file { "/var/log/jetty":
-    ensure  => "${home}/jetty/logs",
+    ensure  => "${home}/jetty/logs";
+  } ->
+
+  file { "/etc/default/jetty":
+    content => "JETTY_HOME=${home}/jetty";
   } ->
 
   file { "/etc/init.d/jetty":
-    ensure => "${home}/jetty-distribution-${version}/bin/jetty.sh"
-  } ->
+    ensure  => "${home}/jetty-distribution-${version}/bin/jetty.sh";
+  } ~>
 
-  service {"jetty":
+  service { "jetty":
     enable     => true,
     ensure     => running,
     hasstatus  => false,
-    hasrestart => true,
+    hasrestart => true;
   }
-  
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,7 +50,7 @@ class jetty (
   } ->
 
   file { "/etc/default/jetty":
-    content => "JETTY_HOME=${home}/jetty";
+    source => template('jetty/default');
   } ->
 
   file { "/etc/init.d/jetty":

--- a/templates/default
+++ b/templates/default
@@ -1,0 +1,2 @@
+JETTY_HOME="<%= @home %>/jetty"
+JETTY_USER="<%= @user %>/jetty"

--- a/templates/default
+++ b/templates/default
@@ -1,2 +1,2 @@
 JETTY_HOME="<%= @home %>/jetty"
-JETTY_USER="<%= @user %>/jetty"
+JETTY_USER="<%= @user %>"


### PR DESCRIPTION
This pull request introduces the following changes;
1. User and Group are now (optionally) created. To ensure no API breakage, the default is to not manage.
2. The jetty distribution folder is now managed by Puppet instead of chowning in the wget, allowing greater control of resource flow.
3. The jetty_untar exec now requires the User and Group to exist. This means the user/group must be managed in Puppet _somewhere_, but not necessarily by the jetty module itself
4. The jetty service is now notified when the symlink changes, not when jetty is extracted (since it would still be pointing to the old dir)
5. /etc/default/jetty is now managed, which specifies the path to JETTY_HOME since the init script is no longer smart enough to determine this itself.

Tested and working on CentOS 6.5 and Debian 7.
