### PR TITLE
Added ensure => present to group definition

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,7 +17,9 @@ class jetty(
       before     => Exec['jetty_untar'],
     })
 
-    ensure_resource('group', $group)
+    ensure_resource('group', $group, { 
+      ensure => present
+    })
   }
 
   wget::fetch { "jetty_download":


### PR DESCRIPTION
Added ensure => present to ensure_resources(group...) statement, fixing the following error when creating the user account on CentOS 6.5/Puppet 3.4.2:

Error: Could not create user jetty: Execution of '/usr/sbin/useradd -g jetty -m -r jetty' returned 6: useradd: group 'jetty' does not exist

Error: /Stage[main]/Jetty/User[jetty]/ensure: change from absent to present failed: Could not create user jetty: Execution of '/usr/sbin/useradd -g jetty -m -r jetty' returned 6: useradd: group 'jetty' does not exist
